### PR TITLE
magictime_docs: Adding a reference to the go docs for formatting

### DIFF
--- a/website/source/docs/templates/engine.html.md
+++ b/website/source/docs/templates/engine.html.md
@@ -254,6 +254,9 @@ Formatting for the function `isotime` uses the magic reference date **Mon Jan 2
 
 *The values in parentheses are the abbreviated, or 24-hour clock values*
 
+For those unfamiliar with GO date/time formatting, here is a link to the
+documentation: [go date/time formatting](https://programming.guide/go/format-parse-string-time-date-example.html)
+
 Note that "-0700" is always formatted into "+0000" because `isotime` is always
 UTC time.
 


### PR DESCRIPTION
Packer might be the first time someone encounters the GO method of formatting date/time as a string. The documentation makes sense if you are already familiar with the GO method, however if your experience is Java/Python/C, then all bets are off. The GO docs include a direct comparison to the other languages which speeds comprehension.